### PR TITLE
Update LandroidS.ts

### DIFF
--- a/src/LandroidS.ts
+++ b/src/LandroidS.ts
@@ -177,7 +177,7 @@ export class LandroidS {
                 } else if (payload === "stop") {
                     this.stopMower();
                 } else {
-                    this.log.error("Invalid MQTT payload for topic %s", topic);
+                    this.log.error("Invalid MQTT payload for topic %s", payload %s, topic, payload);
                 }
             } else if (topic === "set/rainDelay") {
                 this.setRainDelay(payload);


### PR DESCRIPTION
`mosquitto_pub -h vevedock -t 'landroid/set/mow' -m "stop"`
is generation and error:
`landroid_landroid.1.88y4dpx7iq8p@vevedock-01    | [2019-05-11T17:43:29.081] [INFO] Mqtt - Incoming MQTT message to topic landroid/set/mow: stop
landroid_landroid.1.88y4dpx7iq8p@vevedock-01    | [2019-05-11T17:43:29.082] [ERROR] LandroidS - Invalid MQTT payload for topic set/mow payload stop
`
This at least shows the payload but does not help any further, will open an issue