### PR TITLE
Add "pause" function

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,8 @@ To connect this Landroid Bridge to [OpenHAB](http://www.openhab.org/), add the f
 ## HTTP REST URLs
 * Get status as JSON: GET /landroid-s/status
 * Start mower: POST /landroid-s/start
-* Stop mower: POST /landroid-s/stop
+* Send mower home: POST /landroid-s/stop
+* Pause mower: POST /landroid-s/pause
 * Set rain delay: PUT /landroid-s/set/rainDelay/x (where 0 <= x <= 300)
 * Set time extension: PUT /landroid-s/set/timeExtension/x (where -100 <= x <= 100)
 * Set work time schedule: PUT /landroid-s/set/schedule/n (where 0 <= n <= 6, 0 is Sunday)
@@ -228,7 +229,8 @@ curl -X PUT -H "Content-Type: application/json" -d '{"startHour":10,"startMinute
 ### Published by your application (the bridge will perform updates)
 * landroid/set/start (starts the mower)
 * landroid/set/stop (stops the mower and sends it home)
-* landroid/set/mow (payload "start" starts the mower, "stop" stops the mower)
+* landroid/set/pause (stops the mower)
+* landroid/set/mow (payload "start" starts the mower, "stop" sends the mover home, "pause" stops the mower)
 * landroid/set/rainDelay (sets rain delay in minutes, supply delay value as payload)
 * landroid/set/timeExtension (sets time extension in percent, supply percentage value as payload)
 * landroid/set/schedule/n (sets work time for weekday n, where 0 is Sunday – see examples below)

--- a/src/LandroidS.ts
+++ b/src/LandroidS.ts
@@ -29,6 +29,10 @@ export class LandroidS {
         this.sendMessage(1);
     }
 
+    public pauseMower(): void {
+        this.sendMessage(2);
+    }
+
     public stopMower(): void {
         this.sendMessage(3);
     }
@@ -171,11 +175,15 @@ export class LandroidS {
                 this.startMower();
             } else if (topic === "set/stop") {
                 this.stopMower();
+            } else if (topic === "set/pause") {
+                this.pauseMower();
             } else if (topic === "set/mow") {
                 if (String(payload) === "start") {
                     this.startMower();
                 } else if (String(payload) === "stop") {
                     this.stopMower();
+                } else if (String(payload) === "pause") {
+                    this.pauseMower();
                 } else {
                     this.log.error("Invalid MQTT payload for topic %s: %s", topic, payload);
                 }

--- a/src/LandroidSRouter.ts
+++ b/src/LandroidSRouter.ts
@@ -8,6 +8,7 @@ class LandroidSRouter extends BaseRouter {
         this.router.get("/status", this.status.bind(this));
         this.router.post("/start", this.startMower.bind(this));
         this.router.post("/stop", this.stopMower.bind(this));
+        this.router.post("/pause", this.pauseMower.bind(this));
         this.router.put("/set/rainDelay/:value", this.setRainDelay.bind(this));
         this.router.put("/set/timeExtension/:value", this.setTimeExtension.bind(this));
         this.router.put("/set/schedule/:weekday", this.setSchedule.bind(this));
@@ -29,6 +30,11 @@ class LandroidSRouter extends BaseRouter {
 
     private stopMower(req: Request, res: Response, next: NextFunction): void {
         LandroidS.getInstance().stopMower();
+        this.ok(res);
+    }
+
+    private pauseMower(req: Request, res: Response, next: NextFunction): void {
+        LandroidS.getInstance().pauseMower();
         this.ok(res);
     }
 

--- a/src/Scheduler.ts
+++ b/src/Scheduler.ts
@@ -35,7 +35,7 @@ export class Scheduler {
                     let item = schedule[key];
                     let date = moment(key);
                     settings.push([date, item.durationMinutes]);
-                    if (i <= 7) {
+                    if (i < 7) {
                         LandroidS.getInstance().setSchedule(date.weekday(), item.serialize());
                     }
                 });

--- a/src/Scheduler.ts
+++ b/src/Scheduler.ts
@@ -326,7 +326,7 @@ export class Scheduler {
                     let date = startDate.clone().subtract(i, "days");
                     dates.push(date.format("YYYY-MM-DD"));
                 }
-                db.all("SELECT * FROM schedule WHERE date IN (?)", dates, (e, rows) => {
+                db.all("SELECT * FROM schedule WHERE date IN ("+dates+")", (e, rows) => {
                     if (e) {
                         reject(e);
                         return;


### PR DESCRIPTION
Currently the "stop" command does not stop the mower but sends it home (maybe we should relabel this function from "stop" to "home", since it currently is misleading, or add an alias "home" to keep backward compatibility).
This patch adds an additional command "pause", which really stops the mower (and sends it into sleep mode, as if you press the "stop" button on the mower or the pause button in the app).

This should solve issue #41.