### PR TITLE
Add support for GPS coordinates from FindMyLandroid module

### DIFF
--- a/src/LandroidDataset.ts
+++ b/src/LandroidDataset.ts
@@ -18,6 +18,8 @@ export class LandroidDataset {
     batteryVoltage: number;
     batteryTemperature: number;
     batteryLevel: number;
+    gpsLongitude: number;
+    gpsLatitude: number;
     pitch: number;
     roll: number;
     yaw: number;
@@ -52,6 +54,8 @@ export class LandroidDataset {
             batteryVoltage: this.batteryVoltage,
             batteryTemperature: this.batteryTemperature,
             batteryLevel: this.batteryLevel,
+            gpsLatitude: this.gpsLatitude,
+            gpsLongitude: this.gpsLongitude,
             pitch: this.pitch,
             roll: this.roll,
             yaw: this.yaw,
@@ -112,6 +116,12 @@ export class LandroidDataset {
                 this.roll  = Number(readings["dat"]["dmp"][1]).valueOf();
                 this.yaw   = Number(readings["dat"]["dmp"][2]).valueOf();
             }
+            if (readings["dat"]["modules"]) {
+                if (readings["dat"]["modules"]["4G"]) {
+		    this.gpsLatitude=Number(readings["dat"]["modules"]["4G"]["gps"]["coo"][0]).valueOf();
+		    this.gpsLongitude=Number(readings["dat"]["modules"]["4G"]["gps"]["coo"][1]).valueOf();
+		}
+	    }
         }
     }
 


### PR DESCRIPTION
As soon as you have installed the FindMyLandroid module the status message also contains GPS coordinates. Actually they are really easy to get from the status message and to publish them to MQTT.