### PR TITLE
Ignore day 8, which otherwise overwrites todays schedule.

### DIFF
--- a/src/Scheduler.ts
+++ b/src/Scheduler.ts
@@ -35,7 +35,7 @@ export class Scheduler {
                     let item = schedule[key];
                     let date = moment(key);
                     settings.push([date, item.durationMinutes]);
-                    if (i <= 7) {
+                    if (i < 7) {
                         LandroidS.getInstance().setSchedule(date.weekday(), item.serialize());
                     }
                 });


### PR DESCRIPTION
When writing the schedule to the landroid cloud, the data for day 8 overwrites the schedule for today.
So if the forecast for today (day 1) is great while the forecast for next week (day 8) is rainy, the landroid won't go out, because the schedule for day 8 overwrites todays schedule.
This patch excludes day 8 from the scheduler update.

This partly fixes #60 (TODO: update all schedules on the Landroid cloud with one sendMessage() instead of seven).