### PR TITLE
The ? notation in SQL queries does not work for lists.

### DIFF
--- a/src/Scheduler.ts
+++ b/src/Scheduler.ts
@@ -326,7 +326,7 @@ export class Scheduler {
                     let date = startDate.clone().subtract(i, "days");
                     dates.push(date.format("YYYY-MM-DD"));
                 }
-                db.all("SELECT * FROM schedule WHERE date IN (?)", dates, (e, rows) => {
+                db.all("SELECT * FROM schedule WHERE date IN (" + dates + ")", (e, rows) => {
                     if (e) {
                         reject(e);
                         return;


### PR DESCRIPTION
If I set `daysForTotalCut` in `config.json` to 3, this results in the error message `Unhandled rejection: Error: SQLITE_RANGE: column index out of range.`, because `dates` now is a list of two dates, which  isn't accepted by the SQL `?` syntax.

This should fix #68 