### PR TITLE
Update LandroidSRouter.ts

### DIFF
--- a/src/LandroidSRouter.ts
+++ b/src/LandroidSRouter.ts
@@ -42,7 +42,7 @@ class LandroidSRouter extends BaseRouter {
     private setRainDelay(req: Request, res: Response, next: NextFunction): void {
         let value = req.params.value;
         try {
-            LandroidS.getInstance().setRainDelay(value);
+            LandroidS.getInstance().setRainDelay(+value);
             this.ok(res);
         } catch (e) {
             this.badRequest(res, e.message);
@@ -52,7 +52,7 @@ class LandroidSRouter extends BaseRouter {
     private setTimeExtension(req: Request, res: Response, next: NextFunction): void {
         let value = req.params.value;
         try {
-            LandroidS.getInstance().setTimeExtension(value);
+            LandroidS.getInstance().setTimeExtension(+value);
             this.ok(res);
         } catch (e) {
             this.badRequest(res, e.message);
@@ -63,7 +63,7 @@ class LandroidSRouter extends BaseRouter {
         let weekday = req.params.weekday;
         let payload = req.body;
         try {
-            LandroidS.getInstance().setSchedule(weekday, payload);
+            LandroidS.getInstance().setSchedule(+weekday, payload);
             this.ok(res);
         } catch (e) {
             this.badRequest(res, e.message);


### PR DESCRIPTION
fixes string to number error:
src/LandroidSRouter.ts(45,50): error TS2345: Argument of type 'string' is not assignable to parameter of type 'number'.
src/LandroidSRouter.ts(55,54): error TS2345: Argument of type 'string' is not assignable to parameter of type 'number'.
src/LandroidSRouter.ts(66,49): error TS2345: Argument of type 'string' is not assignable to parameter of type 'number'.