### PR TITLE
Introducing multi-staged Docker build to reduce final image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:11-alpine
+FROM node:11-alpine AS prod
 
 WORKDIR /usr/src/app
 
@@ -6,13 +6,26 @@ WORKDIR /usr/src/app
 COPY package*.json .
 
 # Restore node modules
-RUN npm install
+RUN npm install --production
+
+
+
+## BUILD STEP
+FROM prod AS build
 
 # Add everything else not excluded by .dockerignore
 COPY . .
 
 # Build it
-RUN npm run build-prod
+RUN npm install && \
+    npm run build-prod
+
+
+
+## FINAL STEP
+FROM prod as final
+
+COPY --from=build /usr/src/app/dist ./dist
 
 EXPOSE 3000
 CMD [ "node", "dist/server.js" ]


### PR DESCRIPTION
With these changes I was able to reduce the final image size by approx. 50 MB. This is achieved by running the `npm install` step inside a staged build container. We don't need the NPM dev dependencies in the final container, they are only required for building the app (compiling the TypeScript into JavaScript).

```bash
$ docker images
REPOSITORY                    TAG      IMAGE ID            CREATED             SIZE
virtualzone/landroid-bridge   mytag    0b8bd20b11ce        19 minutes ago      145MB
<none>                        <none>   f76a0c4c2f45        19 minutes ago      146MB
<none>                        <none>   c8e74fe7a63a        28 minutes ago      145MB
<none>                        <none>   3f059026230b        28 minutes ago      146MB
virtualzone/landroid-bridge   latest   b01b84f6ada9        8 months ago        192MB
```
Please note the `<none>` images and tags, those are from the intermediate build steps and can safely be removed afterwards if you care about disk usage and do not intend to build again in the near future.