### PR TITLE
Use worx api from github instead of npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "cache": "^2.1.0",
     "cron": "^1.7.1",
     "express": "^4.17.0",
-    "iobroker.landroid-s": "^2.5.5",
+    "iobroker.landroid-s": "github:MeisterTR/ioBroker.landroid-s",
     "log4js": "^4.3.0",
     "moment": "^2.24.0",
     "mqtt": "^2.18.8",


### PR DESCRIPTION
@MeisterTR seems to have updated to the new API in his Github repository, but never updated the NPM repository.

With this patch the Github version is used, which works. At least for me.

Should fix #93, #88, #86 and possibly #84.