### PR TITLE
Added a Dockerfile for native build on ARM machines

### DIFF
--- a/Dockerfile.nativeARM
+++ b/Dockerfile.nativeARM
@@ -1,0 +1,35 @@
+FROM node:12-alpine AS prod
+
+WORKDIR /usr/src/app
+
+# Add package.json
+COPY package*.json .
+
+RUN apk update && apk add --virtual build-dependencies build-base git python
+
+# Restore node modules
+RUN npm install --production
+
+
+
+## BUILD STEP
+FROM prod AS build
+
+# Add everything else not excluded by .dockerignore
+COPY . .
+
+# Build it
+RUN npm install && \
+    npm run build-prod
+
+
+
+## FINAL STEP
+FROM prod as final
+
+RUN apk del build-dependencies
+
+COPY --from=build /usr/src/app/dist ./dist
+
+EXPOSE 3000
+CMD [ "node", "dist/server.js" ]


### PR DESCRIPTION
The new Docker images are working now in terms of running at all, but they still use the wrong API. This can be fixed by #95.

But while debugging I tried to build the Docker image on my Raspi and none of the provided Dockerfiles worked. Mostly because there is no sqlite3 pre-built for ARM and building sqlite3 fails for missing dependencies.

The added Dockerfile builds natively on ARM. Or at least on my Raspi 4.

Probably fixes #72 and #62.